### PR TITLE
Add Python versions to Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
That will fix caniusepython3.com and requires.io version parsing.